### PR TITLE
chore: improve Dependabot scheduling, grouping, and labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,51 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 5
+    labels:
+      - "⬆️ dependencies"
+    commit-message:
+      prefix: "⬆️ deps"
+      include: "scope"
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "07:30"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 5
+    labels:
+      - "⬆️ dependencies"
+      - "⚙️ github-actions"
+    commit-message:
+      prefix: "⚙️ ci"
+      include: "scope"
+    groups:
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## Why
Dependabot was configured with a minimal setup, and some label names did not match the repository labels, which can fail when Dependabot tries to apply them. This update makes dependency update PRs more reliable and easier to triage.

## What changed
- Added explicit weekly schedules for both ecosystems with `Europe/Madrid` timezone.
- Added `open-pull-requests-limit: 5` to avoid too many concurrent update PRs.
- Added grouped updates for both ecosystems:
  - `minor/patch` updates grouped together.
  - `major` updates grouped separately.
- Updated Dependabot labels to existing repo labels with emoji:
  - `⬆️ dependencies`
  - `⚙️ github-actions`
- Added emoji commit prefixes for Dependabot PRs:
  - npm: `⬆️ deps`
  - github-actions: `⚙️ ci`

## Notes for reviewers
Only `.github/dependabot.yml` was changed. No runtime code or application dependencies were modified in this PR.